### PR TITLE
✨ Implement get-authorization-url endpoint

### DIFF
--- a/app/auth/constants.py
+++ b/app/auth/constants.py
@@ -35,3 +35,9 @@ class ErrorEnum(BaseErrorEnum):
 
 class VerificationUsage(StrEnum):
     SIGN_UP = "SIGN_UP"
+
+
+class OAuth2Provider(StrEnum):
+    GOOGLE = "google"
+    KAKAO = "kakao"
+    APPLE = "apple"

--- a/app/auth/deps.py
+++ b/app/auth/deps.py
@@ -1,15 +1,19 @@
 from collections.abc import Callable
-from typing import Annotated
+from typing import Annotated, Any
 
 import jwt
 from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jwt import PyJWTError
 
-from app.auth.constants import ErrorEnum
+from app.auth.constants import ErrorEnum, OAuth2Provider
 from app.core.config import config
 from app.core.deps import SessionDep
 from app.core.errors import PermissionDenied, UnauthorizedError
+from app.core.oauth2.apple import AppleOAuth2
+from app.core.oauth2.base import OAuth2Base
+from app.core.oauth2.google import GoogleOAuth2
+from app.core.oauth2.kakao import KakaoOAuth2
 from app.user.models import User
 
 
@@ -58,3 +62,30 @@ def require_auth() -> Callable[[CurrentUserDep], None]:
             raise PermissionDenied(ErrorEnum.USER_NOT_AUTHENTICATED)
 
     return _require_auth
+
+
+def oauth_provider(provider: OAuth2Provider) -> OAuth2Base[Any]:
+    match provider:
+        case OAuth2Provider.GOOGLE:
+            return GoogleOAuth2(
+                client_id=config.google_client_id,
+                client_secret=config.google_client_secret,
+                redirect_uri=config.google_redirect_uri,
+            )
+        case OAuth2Provider.APPLE:
+            return AppleOAuth2(
+                client_id=config.apple_client_id,
+                team_id=config.apple_team_id,
+                key_id=config.apple_key_id,
+                private_key=config.apple_private_key,
+                redirect_uri=config.apple_redirect_uri,
+            )
+        case OAuth2Provider.KAKAO:
+            return KakaoOAuth2(
+                client_id=config.kakao_client_id,
+                client_secret=config.kakao_client_secret,
+                redirect_uri=config.kakao_redirect_uri,
+            )
+
+
+OAuth2ProviderDep = Annotated[OAuth2Base[Any], Depends(oauth_provider)]

--- a/app/auth/endpoints.py
+++ b/app/auth/endpoints.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Body, Cookie, Response
 from pydantic import EmailStr
 
 from app.auth.constants import ErrorEnum
+from app.auth.deps import OAuth2ProviderDep
 from app.auth.dto import (
     AccessTokenResponse,
     AuthenticatedUser,
@@ -20,7 +21,7 @@ from app.core.config import config
 from app.core.deps import EmailBackendDep, SessionDep
 from app.core.errors import ValidationError
 
-router = APIRouter()
+router = APIRouter(tags=["auth"])
 
 
 @router.post("/sign-in/email")
@@ -121,14 +122,13 @@ def generate_access_token(user_id: UUID):
 
 
 @router.post("/oauth2/{provider}/get-authorization-url")
-async def oauth2_authorize(
-    response: Response,
-    session: SessionDep,
-): ...
+async def get_oauth2_authorization_url(
+    provider: OAuth2ProviderDep,
+):
+    return provider.get_authorization_url()
 
 
 @router.get("/oauth2/{provider}/callback")
 async def oauth2_callback(
-    response: Response,
     session: SessionDep,
 ): ...


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Fb3NN8xAIBD3Qg4dm0N5/2448bb23-b69b-49e4-ac95-1f02c77f4252.png)


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces OAuth2 support for Google, Kakao, and Apple in the authentication module. It also refactors the existing code to accommodate these changes.
> 
> ## What changed
> 1. **app/auth/constants.py**: Added a new `OAuth2Provider` enum with `GOOGLE`, `KAKAO`, and `APPLE` as its members.
> 2. **app/auth/deps.py**: Added a new dependency `oauth_provider` that returns an instance of the appropriate OAuth2 class based on the provider. Also, added the necessary import statements for the OAuth2 classes.
> 3. **app/auth/endpoints.py**: Modified the `router` to include the tag "auth". Added new endpoints for getting the authorization URL and handling the callback for each OAuth2 provider.
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Update your environment variables to include the necessary credentials for each OAuth2 provider.
> 3. Run the application and make a `POST` request to `/oauth2/{provider}/get-authorization-url` endpoint. Replace `{provider}` with either `google`, `kakao`, or `apple`.
> 4. You should receive a URL in the response. Visit this URL and authorize the application.
> 5. You will be redirected to a callback URL. The application should handle this request and log you in.
> 
> ## Why make this change
> Integrating OAuth2 allows users to sign in with their Google, Kakao, or Apple accounts, providing a more convenient and secure way of authentication. This is a common feature in many modern web applications and is expected by many users.
</details>